### PR TITLE
Update conda yml file env name

### DIFF
--- a/nerf_factory.yml
+++ b/nerf_factory.yml
@@ -1,4 +1,4 @@
-name: base
+name: nerf_factory
 channels:
   - pytorch
   - nvidia


### PR DESCRIPTION
Closes https://github.com/kakaobrain/NeRF-Factory/issues/7

Changing the conda env name from `base` -> `nerf_factory` for 2 reasons:
1. Running `conda env create --file nerf_factory.yml` gives an error `CondaValueError: prefix already exists: /home/mishig/miniconda3` because `base` is a "reverved" name
2. [Docs](https://kakaobrain.github.io/NeRF-Factory/docs/installation/#environment-setting) suggest that the name should be `nerf_factory`

Thanks a lot! 👍 