### PR TITLE
add .cpu() to the returned value of render_rays()

### DIFF
--- a/src/model/dvgo/model.py
+++ b/src/model/dvgo/model.py
@@ -519,9 +519,9 @@ class LitDVGO(LitModel):
             rays_o, rays_d, viewdirs, is_train=False, **self.get_render_kwargs()
         )
 
-        ret["rgb"] = render_result["rgb_marched"]
+        ret["rgb"] = render_result["rgb_marched"].cpu()
         if "target" in batch:
-            ret["target"] = target
+            ret["target"] = target.cpu()
         return ret
 
     def validation_step(self, batch, batch_idx):

--- a/src/model/mipnerf/model.py
+++ b/src/model/mipnerf/model.py
@@ -254,8 +254,8 @@ class LitMipNeRF(LitModel):
         )
         rgb_fine = rendered_results[1][0]
         target = batch["target"]
-        ret["target"] = target
-        ret["rgb"] = rgb_fine
+        ret["target"] = target.cpu()
+        ret["rgb"] = rgb_fine.cpu()
         return ret
 
     def validation_step(self, batch, batch_idx):

--- a/src/model/mipnerf360/model.py
+++ b/src/model/mipnerf360/model.py
@@ -427,8 +427,8 @@ class LitMipNeRF360(LitModel):
         )
         rgb = rendered_results[-1]["rgb"]
         target = batch["target"]
-        ret["target"] = target
-        ret["rgb"] = rgb
+        ret["target"] = target.cpu()
+        ret["rgb"] = rgb.cpu()
         return ret
 
     def validation_step(self, batch, batch_idx):

--- a/src/model/nerf/model.py
+++ b/src/model/nerf/model.py
@@ -243,8 +243,8 @@ class LitNeRF(LitModel):
         )
         rgb_fine = rendered_results[1][0]
         target = batch["target"]
-        ret["target"] = target
-        ret["rgb"] = rgb_fine
+        ret["target"] = target.cpu()
+        ret["rgb"] = rgb_fine.cpu()
         return ret
 
     def validation_step(self, batch, batch_idx):

--- a/src/model/nerfpp/model.py
+++ b/src/model/nerfpp/model.py
@@ -290,8 +290,8 @@ class LitNeRFPP(LitModel):
         )
         rgb_fine = rendered_results[1][0]
         target = batch["target"]
-        ret["target"] = target
-        ret["rgb"] = rgb_fine
+        ret["target"] = target.cpu()
+        ret["rgb"] = rgb_fine.cpu()
         return ret
 
     def validation_step(self, batch, batch_idx):

--- a/src/model/refnerf/model.py
+++ b/src/model/refnerf/model.py
@@ -370,8 +370,8 @@ class LitRefNeRF(LitModel):
         )
         rgb_fine = rendered_results[1]["comp_rgb"]
         target = batch["target"]
-        ret["target"] = target
-        ret["rgb"] = rgb_fine
+        ret["target"] = target.cpu()
+        ret["rgb"] = rgb_fine.cpu()
         return ret
 
     def validation_step(self, batch, batch_idx):

--- a/utils/store_image.py
+++ b/utils/store_image.py
@@ -22,7 +22,7 @@ def norm8b(x):
 
 def store_image(dirpath, rgbs):
     for (i, rgb) in enumerate(rgbs):
-        imgname = f"image{str(i).zfill(3)}.jpg"
+        imgname = f"image{str(i).zfill(3)}.png"
         rgbimg = Image.fromarray(to8b(rgb.detach().cpu().numpy()))
         imgpath = os.path.join(dirpath, imgname)
         rgbimg.save(imgpath)


### PR DESCRIPTION
# Issue
To calculate the psnr, it looks like the program will store all the reconstructed images and ground truth in the GPU until the end of the inference. This may suffer from OOM if the user's GPU memory is limited or the user's testing set contains several high-resolution images. 
# Solution
We can move them to CPU memory by .cpu() or even .detach().cpu() before we return the value from the render_rays(). This is similar to what you have done [here](https://github.com/kakaobrain/NeRF-Factory/blob/main/src/model/plenoxel/model.py) for plenoxel.