### PR TITLE
Save as png format instead of jpg format

### DIFF
--- a/utils/store_image.py
+++ b/utils/store_image.py
@@ -22,7 +22,7 @@ def norm8b(x):
 
 def store_image(dirpath, rgbs):
     for (i, rgb) in enumerate(rgbs):
-        imgname = f"image{str(i).zfill(3)}.jpg"
+        imgname = f"image{str(i).zfill(3)}.png"
         rgbimg = Image.fromarray(to8b(rgb.detach().cpu().numpy()))
         imgpath = os.path.join(dirpath, imgname)
         rgbimg.save(imgpath)


### PR DESCRIPTION
jpg is lossy compression. Hence, users may get different psnr if they compute psnr offline with saved jpg files.