### PR TITLE
added evaluation metrics: msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, fid

### DIFF
--- a/src/model/dvgo/model.py
+++ b/src/model/dvgo/model.py
@@ -536,10 +536,26 @@ class LitDVGO(LitModel):
         targets = self.alter_gather_cat(outputs, "target", val_image_sizes)
         psnr_mean = self.psnr_each(rgbs, targets).mean()
         ssim_mean = self.ssim_each(rgbs, targets).mean()
+        msssim_mean = self.msssim_each(rgbs, targets).mean()
+        gmsd_mean = self.gmsd_each(rgbs, targets).mean()
+        msgmsd_mean = self.msgmsd_each(rgbs, targets).mean()
+        mdsi_mean = self.mdsi_each(rgbs, targets).mean()
+        haarpsi_mean = self.haarpsi_each(rgbs, targets).mean()
+        vsi_mean = self.vsi_each(rgbs, targets).mean()
+        fsim_mean = self.fsim_each(rgbs, targets).mean()
         lpips_mean = self.lpips_each(rgbs, targets).mean()
+        fid_mean = self.fid_each(rgbs, targets).mean()
         self.log("val/psnr", psnr_mean.item(), on_epoch=True, sync_dist=True)
         self.log("val/ssim", ssim_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/msssim", msssim_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/gmsd", gmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/msgmsd", msgmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/mdsi", mdsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/haarpsi", haarpsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/vsi", vsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/fsim", fsim_mean.item(), on_epoch=True,  sync_dist=True)
         self.log("val/lpips", lpips_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/fid", fid_mean.item(), on_epoch=True,  sync_dist=True)
 
     def test_epoch_end(self, outputs):
         dmodule = self.trainer.datamodule
@@ -552,13 +568,29 @@ class LitDVGO(LitModel):
         targets = self.alter_gather_cat(outputs, "target", all_image_sizes)
         psnr = self.psnr(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         ssim = self.ssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msssim = self.msssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        gmsd = self.gmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msgmsd = self.msgmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        mdsi = self.mdsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        haarpsi = self.haarpsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        vsi = self.vsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        fsim = self.fsim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         lpips = self.lpips(
             rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test
         )
+        fid = self.fid(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
 
         self.log("test/psnr", psnr["test"], on_epoch=True)
         self.log("test/ssim", ssim["test"], on_epoch=True)
+        self.log("test/msssim", msssim["test"], on_epoch=True)
+        self.log("test/gmsd", gmsd["test"], on_epoch=True)
+        self.log("test/msgmsd", msgmsd["test"], on_epoch=True)
+        self.log("test/mdsi", mdsi["test"], on_epoch=True)
+        self.log("test/haarpsi", haarpsi["test"], on_epoch=True)
+        self.log("test/vsi", vsi["test"], on_epoch=True)
+        self.log("test/fsim", fsim["test"], on_epoch=True)
         self.log("test/lpips", lpips["test"], on_epoch=True)
+        self.log("test/fid", fid["test"], on_epoch=True)
 
         if self.trainer.is_global_zero:
             image_dir = os.path.join(self.logdir, "render_model")
@@ -566,9 +598,9 @@ class LitDVGO(LitModel):
             store_image.store_image(image_dir, rgbs)
 
             result_path = os.path.join(self.logdir, "results.json")
-            self.write_stats(result_path, psnr, ssim, lpips)
+            self.write_stats(result_path, psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid)
 
-        return psnr, ssim, lpips
+        return psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid
 
     @torch.no_grad()
     def compute_bbox_by_coarse_geo(self, model_class, model_path, thres):

--- a/src/model/mipnerf/model.py
+++ b/src/model/mipnerf/model.py
@@ -305,10 +305,26 @@ class LitMipNeRF(LitModel):
         targets = self.alter_gather_cat(outputs, "target", val_image_sizes)
         psnr_mean = self.psnr_each(rgbs, targets).mean()
         ssim_mean = self.ssim_each(rgbs, targets).mean()
+        msssim_mean = self.msssim_each(rgbs, targets).mean()
+        gmsd_mean = self.gmsd_each(rgbs, targets).mean()
+        msgmsd_mean = self.msgmsd_each(rgbs, targets).mean()
+        mdsi_mean = self.mdsi_each(rgbs, targets).mean()
+        haarpsi_mean = self.haarpsi_each(rgbs, targets).mean()
+        vsi_mean = self.vsi_each(rgbs, targets).mean()
+        fsim_mean = self.fsim_each(rgbs, targets).mean()
         lpips_mean = self.lpips_each(rgbs, targets).mean()
+        fid_mean = self.fid_each(rgbs, targets).mean()
         self.log("val/psnr", psnr_mean.item(), on_epoch=True, sync_dist=True)
         self.log("val/ssim", ssim_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/msssim", msssim_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/gmsd", gmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/msgmsd", msgmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/mdsi", mdsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/haarpsi", haarpsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/vsi", vsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/fsim", fsim_mean.item(), on_epoch=True,  sync_dist=True)
         self.log("val/lpips", lpips_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/fid", fid_mean.item(), on_epoch=True,  sync_dist=True)
 
     def test_epoch_end(self, outputs):
         dmodule = self.trainer.datamodule
@@ -321,13 +337,29 @@ class LitMipNeRF(LitModel):
         targets = self.alter_gather_cat(outputs, "target", all_image_sizes)
         psnr = self.psnr(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         ssim = self.ssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msssim = self.msssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        gmsd = self.gmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msgmsd = self.msgmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        mdsi = self.mdsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        haarpsi = self.haarpsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        vsi = self.vsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        fsim = self.fsim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         lpips = self.lpips(
             rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test
         )
+        fid = self.fid(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
 
         self.log("test/psnr", psnr["test"], on_epoch=True)
         self.log("test/ssim", ssim["test"], on_epoch=True)
+        self.log("test/msssim", msssim["test"], on_epoch=True)
+        self.log("test/gmsd", gmsd["test"], on_epoch=True)
+        self.log("test/msgmsd", msgmsd["test"], on_epoch=True)
+        self.log("test/mdsi", mdsi["test"], on_epoch=True)
+        self.log("test/haarpsi", haarpsi["test"], on_epoch=True)
+        self.log("test/vsi", vsi["test"], on_epoch=True)
+        self.log("test/fsim", fsim["test"], on_epoch=True)
         self.log("test/lpips", lpips["test"], on_epoch=True)
+        self.log("test/fid", fid["test"], on_epoch=True)
 
         if self.trainer.is_global_zero:
             image_dir = os.path.join(self.logdir, "render_model")
@@ -335,6 +367,6 @@ class LitMipNeRF(LitModel):
             store_image.store_image(image_dir, rgbs)
 
             result_path = os.path.join(self.logdir, "results.json")
-            self.write_stats(result_path, psnr, ssim, lpips)
+            self.write_stats(result_path, psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid)
 
-        return psnr, ssim, lpips
+        return psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid

--- a/src/model/mipnerf360/model.py
+++ b/src/model/mipnerf360/model.py
@@ -478,10 +478,26 @@ class LitMipNeRF360(LitModel):
         targets = self.alter_gather_cat(outputs, "target", val_image_sizes)
         psnr_mean = self.psnr_each(rgbs, targets).mean()
         ssim_mean = self.ssim_each(rgbs, targets).mean()
+        msssim_mean = self.msssim_each(rgbs, targets).mean()
+        gmsd_mean = self.gmsd_each(rgbs, targets).mean()
+        msgmsd_mean = self.msgmsd_each(rgbs, targets).mean()
+        mdsi_mean = self.mdsi_each(rgbs, targets).mean()
+        haarpsi_mean = self.haarpsi_each(rgbs, targets).mean()
+        vsi_mean = self.vsi_each(rgbs, targets).mean()
+        fsim_mean = self.fsim_each(rgbs, targets).mean()
         lpips_mean = self.lpips_each(rgbs, targets).mean()
+        fid_mean = self.fid_each(rgbs, targets).mean()
         self.log("val/psnr", psnr_mean.item(), on_epoch=True, sync_dist=True)
         self.log("val/ssim", ssim_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/msssim", msssim_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/gmsd", gmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/msgmsd", msgmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/mdsi", mdsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/haarpsi", haarpsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/vsi", vsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/fsim", fsim_mean.item(), on_epoch=True,  sync_dist=True)
         self.log("val/lpips", lpips_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/fid", fid_mean.item(), on_epoch=True,  sync_dist=True)
 
     def test_epoch_end(self, outputs):
         dmodule = self.trainer.datamodule
@@ -494,13 +510,29 @@ class LitMipNeRF360(LitModel):
         targets = self.alter_gather_cat(outputs, "target", all_image_sizes)
         psnr = self.psnr(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         ssim = self.ssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msssim = self.msssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        gmsd = self.gmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msgmsd = self.msgmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        mdsi = self.mdsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        haarpsi = self.haarpsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        vsi = self.vsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        fsim = self.fsim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         lpips = self.lpips(
             rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test
         )
+        fid = self.fid(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
 
-        self.log("test/psnr", psnr["test"], on_epoch=True, sync_dist=True)
-        self.log("test/ssim", ssim["test"], on_epoch=True, sync_dist=True)
-        self.log("test/lpips", lpips["test"], on_epoch=True, sync_dist=True)
+        self.log("test/psnr", psnr["test"], on_epoch=True)
+        self.log("test/ssim", ssim["test"], on_epoch=True)
+        self.log("test/msssim", msssim["test"], on_epoch=True)
+        self.log("test/gmsd", gmsd["test"], on_epoch=True)
+        self.log("test/msgmsd", msgmsd["test"], on_epoch=True)
+        self.log("test/mdsi", mdsi["test"], on_epoch=True)
+        self.log("test/haarpsi", haarpsi["test"], on_epoch=True)
+        self.log("test/vsi", vsi["test"], on_epoch=True)
+        self.log("test/fsim", fsim["test"], on_epoch=True)
+        self.log("test/lpips", lpips["test"], on_epoch=True)
+        self.log("test/fid", fid["test"], on_epoch=True)
 
         if self.trainer.is_global_zero:
             image_dir = os.path.join(self.logdir, "render_model")
@@ -508,9 +540,9 @@ class LitMipNeRF360(LitModel):
             store_image.store_image(image_dir, rgbs)
 
             result_path = os.path.join(self.logdir, "results.json")
-            self.write_stats(result_path, psnr, ssim, lpips)
+            self.write_stats(result_path, psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid)
 
-        return psnr, ssim, lpips
+        return psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid
 
     def interlevel_loss(self, ray_history):
         last_ray_results = ray_history[-1]

--- a/src/model/nerf/model.py
+++ b/src/model/nerf/model.py
@@ -294,10 +294,26 @@ class LitNeRF(LitModel):
         targets = self.alter_gather_cat(outputs, "target", val_image_sizes)
         psnr_mean = self.psnr_each(rgbs, targets).mean()
         ssim_mean = self.ssim_each(rgbs, targets).mean()
+        msssim_mean = self.msssim_each(rgbs, targets).mean()
+        gmsd_mean = self.gmsd_each(rgbs, targets).mean()
+        msgmsd_mean = self.msgmsd_each(rgbs, targets).mean()
+        mdsi_mean = self.mdsi_each(rgbs, targets).mean()
+        haarpsi_mean = self.haarpsi_each(rgbs, targets).mean()
+        vsi_mean = self.vsi_each(rgbs, targets).mean()
+        fsim_mean = self.fsim_each(rgbs, targets).mean()
         lpips_mean = self.lpips_each(rgbs, targets).mean()
+        fid_mean = self.fid_each(rgbs, targets).mean()
         self.log("val/psnr", psnr_mean.item(), on_epoch=True, sync_dist=True)
         self.log("val/ssim", ssim_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/msssim", msssim_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/gmsd", gmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/msgmsd", msgmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/mdsi", mdsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/haarpsi", haarpsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/vsi", vsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/fsim", fsim_mean.item(), on_epoch=True,  sync_dist=True)
         self.log("val/lpips", lpips_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/fid", fid_mean.item(), on_epoch=True,  sync_dist=True)
 
     def test_epoch_end(self, outputs):
         dmodule = self.trainer.datamodule
@@ -310,13 +326,29 @@ class LitNeRF(LitModel):
         targets = self.alter_gather_cat(outputs, "target", all_image_sizes)
         psnr = self.psnr(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         ssim = self.ssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msssim = self.msssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        gmsd = self.gmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msgmsd = self.msgmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        mdsi = self.mdsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        haarpsi = self.haarpsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        vsi = self.vsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        fsim = self.fsim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         lpips = self.lpips(
             rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test
         )
+        fid = self.fid(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
 
         self.log("test/psnr", psnr["test"], on_epoch=True)
         self.log("test/ssim", ssim["test"], on_epoch=True)
+        self.log("test/msssim", msssim["test"], on_epoch=True)
+        self.log("test/gmsd", gmsd["test"], on_epoch=True)
+        self.log("test/msgmsd", msgmsd["test"], on_epoch=True)
+        self.log("test/mdsi", mdsi["test"], on_epoch=True)
+        self.log("test/haarpsi", haarpsi["test"], on_epoch=True)
+        self.log("test/vsi", vsi["test"], on_epoch=True)
+        self.log("test/fsim", fsim["test"], on_epoch=True)
         self.log("test/lpips", lpips["test"], on_epoch=True)
+        self.log("test/fid", fid["test"], on_epoch=True)
 
         if self.trainer.is_global_zero:
             image_dir = os.path.join(self.logdir, "render_model")
@@ -324,6 +356,6 @@ class LitNeRF(LitModel):
             store_image.store_image(image_dir, rgbs)
 
             result_path = os.path.join(self.logdir, "results.json")
-            self.write_stats(result_path, psnr, ssim, lpips)
+            self.write_stats(result_path, psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid)
 
-        return psnr, ssim, lpips
+        return psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid

--- a/src/model/nerfpp/model.py
+++ b/src/model/nerfpp/model.py
@@ -341,10 +341,26 @@ class LitNeRFPP(LitModel):
         targets = self.alter_gather_cat(outputs, "target", val_image_sizes)
         psnr_mean = self.psnr_each(rgbs, targets).mean()
         ssim_mean = self.ssim_each(rgbs, targets).mean()
+        msssim_mean = self.msssim_each(rgbs, targets).mean()
+        gmsd_mean = self.gmsd_each(rgbs, targets).mean()
+        msgmsd_mean = self.msgmsd_each(rgbs, targets).mean()
+        mdsi_mean = self.mdsi_each(rgbs, targets).mean()
+        haarpsi_mean = self.haarpsi_each(rgbs, targets).mean()
+        vsi_mean = self.vsi_each(rgbs, targets).mean()
+        fsim_mean = self.fsim_each(rgbs, targets).mean()
         lpips_mean = self.lpips_each(rgbs, targets).mean()
+        fid_mean = self.fid_each(rgbs, targets).mean()
         self.log("val/psnr", psnr_mean.item(), on_epoch=True, sync_dist=True)
         self.log("val/ssim", ssim_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/msssim", msssim_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/gmsd", gmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/msgmsd", msgmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/mdsi", mdsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/haarpsi", haarpsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/vsi", vsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/fsim", fsim_mean.item(), on_epoch=True,  sync_dist=True)
         self.log("val/lpips", lpips_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/fid", fid_mean.item(), on_epoch=True,  sync_dist=True)
 
     def test_epoch_end(self, outputs):
         dmodule = self.trainer.datamodule
@@ -357,13 +373,29 @@ class LitNeRFPP(LitModel):
         targets = self.alter_gather_cat(outputs, "target", all_image_sizes)
         psnr = self.psnr(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         ssim = self.ssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msssim = self.msssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        gmsd = self.gmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msgmsd = self.msgmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        mdsi = self.mdsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        haarpsi = self.haarpsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        vsi = self.vsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        fsim = self.fsim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         lpips = self.lpips(
             rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test
         )
+        fid = self.fid(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
 
         self.log("test/psnr", psnr["test"], on_epoch=True)
         self.log("test/ssim", ssim["test"], on_epoch=True)
+        self.log("test/msssim", msssim["test"], on_epoch=True)
+        self.log("test/gmsd", gmsd["test"], on_epoch=True)
+        self.log("test/msgmsd", msgmsd["test"], on_epoch=True)
+        self.log("test/mdsi", mdsi["test"], on_epoch=True)
+        self.log("test/haarpsi", haarpsi["test"], on_epoch=True)
+        self.log("test/vsi", vsi["test"], on_epoch=True)
+        self.log("test/fsim", fsim["test"], on_epoch=True)
         self.log("test/lpips", lpips["test"], on_epoch=True)
+        self.log("test/fid", fid["test"], on_epoch=True)
 
         if self.trainer.is_global_zero:
             image_dir = os.path.join(self.logdir, "render_model")
@@ -371,6 +403,6 @@ class LitNeRFPP(LitModel):
             store_image.store_image(image_dir, rgbs)
 
             result_path = os.path.join(self.logdir, "results.json")
-            self.write_stats(result_path, psnr, ssim, lpips)
+            self.write_stats(result_path, psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid)
 
-        return psnr, ssim, lpips
+        return psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid

--- a/src/model/plenoxel/model.py
+++ b/src/model/plenoxel/model.py
@@ -472,13 +472,29 @@ class LitPlenoxel(LitModel):
         targets = self.alter_gather_cat(outputs, "target", all_image_sizes)
         psnr = self.psnr(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         ssim = self.ssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msssim = self.msssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        gmsd = self.gmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msgmsd = self.msgmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        mdsi = self.mdsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        haarpsi = self.haarpsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        vsi = self.vsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        fsim = self.fsim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         lpips = self.lpips(
             rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test
         )
+        fid = self.fid(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
 
         self.log("test/psnr", psnr["test"], on_epoch=True)
         self.log("test/ssim", ssim["test"], on_epoch=True)
+        self.log("test/msssim", msssim["test"], on_epoch=True)
+        self.log("test/gmsd", gmsd["test"], on_epoch=True)
+        self.log("test/msgmsd", msgmsd["test"], on_epoch=True)
+        self.log("test/mdsi", mdsi["test"], on_epoch=True)
+        self.log("test/haarpsi", haarpsi["test"], on_epoch=True)
+        self.log("test/vsi", vsi["test"], on_epoch=True)
+        self.log("test/fsim", fsim["test"], on_epoch=True)
         self.log("test/lpips", lpips["test"], on_epoch=True)
+        self.log("test/fid", fid["test"], on_epoch=True)
 
         if self.trainer.is_global_zero:
             image_dir = os.path.join(self.logdir, "render_model")
@@ -486,7 +502,7 @@ class LitPlenoxel(LitModel):
             store_image.store_image(image_dir, rgbs)
 
             self.write_stats(
-                os.path.join(self.logdir, "results.json"), psnr, ssim, lpips
+                os.path.join(self.logdir, "results.json"), psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid
             )
 
     def validation_epoch_end(self, outputs):
@@ -495,10 +511,26 @@ class LitPlenoxel(LitModel):
         targets = self.alter_gather_cat(outputs, "target", val_image_sizes)
         psnr_mean = self.psnr_each(rgbs, targets).mean()
         ssim_mean = self.ssim_each(rgbs, targets).mean()
+        msssim_mean = self.msssim_each(rgbs, targets).mean()
+        gmsd_mean = self.gmsd_each(rgbs, targets).mean()
+        msgmsd_mean = self.msgmsd_each(rgbs, targets).mean()
+        mdsi_mean = self.mdsi_each(rgbs, targets).mean()
+        haarpsi_mean = self.haarpsi_each(rgbs, targets).mean()
+        vsi_mean = self.vsi_each(rgbs, targets).mean()
+        fsim_mean = self.fsim_each(rgbs, targets).mean()
         lpips_mean = self.lpips_each(rgbs, targets).mean()
-        self.log("val/psnr", psnr_mean.item(), on_epoch=True)
-        self.log("val/ssim", ssim_mean.item(), on_epoch=True)
-        self.log("val/lpips", lpips_mean.item(), on_epoch=True)
+        fid_mean = self.fid_each(rgbs, targets).mean()
+        self.log("val/psnr", psnr_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/ssim", ssim_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/msssim", msssim_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/gmsd", gmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/msgmsd", msgmsd_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/mdsi", mdsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/haarpsi", haarpsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/vsi", vsi_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/fsim", fsim_mean.item(), on_epoch=True,  sync_dist=True)
+        self.log("val/lpips", lpips_mean.item(), on_epoch=True, sync_dist=True)
+        self.log("val/fid", fid_mean.item(), on_epoch=True,  sync_dist=True)
         return super().validation_epoch_end(outputs)
 
     def on_save_checkpoint(self, checkpoint) -> None:

--- a/src/model/refnerf/model.py
+++ b/src/model/refnerf/model.py
@@ -424,10 +424,26 @@ class LitRefNeRF(LitModel):
         targets = self.alter_gather_cat(outputs, "target", val_image_sizes)
         psnr_mean = self.psnr_each(rgbs, targets).mean()
         ssim_mean = self.ssim_each(rgbs, targets).mean()
+        msssim_mean = self.msssim_each(rgbs, targets).mean()
+        gmsd_mean = self.gmsd_each(rgbs, targets).mean()
+        msgmsd_mean = self.msgmsd_each(rgbs, targets).mean()
+        mdsi_mean = self.mdsi_each(rgbs, targets).mean()
+        haarpsi_mean = self.haarpsi_each(rgbs, targets).mean()
+        vsi_mean = self.vsi_each(rgbs, targets).mean()
+        fsim_mean = self.fsim_each(rgbs, targets).mean()
         lpips_mean = self.lpips_each(rgbs, targets).mean()
-        self.log("val/psnr", psnr_mean.item(), on_epoch=True, sync_dist=True)
-        self.log("val/ssim", ssim_mean.item(), on_epoch=True, sync_dist=True)
-        self.log("val/lpips", lpips_mean.item(), on_epoch=True, sync_dist=True)
+        fid_mean = self.fid_each(rgbs, targets).mean()
+        self.log("val/psnr", psnr_mean.item(), on_epoch=True, prog_bar=True, sync_dist=True)
+        self.log("val/ssim", ssim_mean.item(), on_epoch=True, prog_bar=True, sync_dist=True)
+        self.log("val/msssim", msssim_mean.item(), on_epoch=True,  prog_bar=True, sync_dist=True)
+        self.log("val/gmsd", gmsd_mean.item(), on_epoch=True,  prog_bar=True, sync_dist=True)
+        self.log("val/msgmsd", msgmsd_mean.item(), on_epoch=True,  prog_bar=True, sync_dist=True)
+        self.log("val/mdsi", mdsi_mean.item(), on_epoch=True,  prog_bar=True, sync_dist=True)
+        self.log("val/haarpsi", haarpsi_mean.item(), on_epoch=True,  prog_bar=True, sync_dist=True)
+        self.log("val/vsi", vsi_mean.item(), on_epoch=True,  prog_bar=True, sync_dist=True)
+        self.log("val/fsim", fsim_mean.item(), on_epoch=True,  prog_bar=True, sync_dist=True)
+        self.log("val/lpips", lpips_mean.item(), on_epoch=True, prog_bar=True, sync_dist=True)
+        self.log("val/fid", fid_mean.item(), on_epoch=True,  prog_bar=True, sync_dist=True)
 
     def test_epoch_end(self, outputs):
         dmodule = self.trainer.datamodule
@@ -440,13 +456,29 @@ class LitRefNeRF(LitModel):
         targets = self.alter_gather_cat(outputs, "target", all_image_sizes)
         psnr = self.psnr(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         ssim = self.ssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msssim = self.msssim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        gmsd = self.gmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        msgmsd = self.msgmsd(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        mdsi = self.mdsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        haarpsi = self.haarpsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        vsi = self.vsi(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
+        fsim = self.fsim(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
         lpips = self.lpips(
             rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test
         )
+        fid = self.fid(rgbs, targets, dmodule.i_train, dmodule.i_val, dmodule.i_test)
 
         self.log("test/psnr", psnr["test"], on_epoch=True)
         self.log("test/ssim", ssim["test"], on_epoch=True)
+        self.log("test/msssim", msssim["test"], on_epoch=True)
+        self.log("test/gmsd", gmsd["test"], on_epoch=True)
+        self.log("test/msgmsd", msgmsd["test"], on_epoch=True)
+        self.log("test/mdsi", mdsi["test"], on_epoch=True)
+        self.log("test/haarpsi", haarpsi["test"], on_epoch=True)
+        self.log("test/vsi", vsi["test"], on_epoch=True)
+        self.log("test/fsim", fsim["test"], on_epoch=True)
         self.log("test/lpips", lpips["test"], on_epoch=True)
+        self.log("test/fid", fid["test"], on_epoch=True)
 
         if self.trainer.is_global_zero:
             image_dir = os.path.join(self.logdir, "render_model")
@@ -454,9 +486,9 @@ class LitRefNeRF(LitModel):
             store_image.store_image(image_dir, rgbs)
 
             result_path = os.path.join(self.logdir, "results.json")
-            self.write_stats(result_path, psnr, ssim, lpips)
+            self.write_stats(result_path, psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid)
 
-        return psnr, ssim, lpips
+        return psnr, ssim, msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim, lpips, fid
 
     def orientation_loss(self, rendered_results, viewdirs):
         total_loss = 0.0


### PR DESCRIPTION
Added full-reference metrics (msssim, gmsd, msgmsd, mdsi, haarpsi, vsi, fsim) and feature-based metrics (fid). All functionality has been implemented in `src/model/interface.py` and exporting its tensorboard test and validation scalars for each existing model in nerf-factory `src/model/*/model.py`

More metrics could be added from piq library (https://github.com/photosynthesis-team/piq?tab=readme-ov-file#list-of-metrics) but at the moment these were the ones relevant to be tested. Extra metrics from piqa (https://github.com/francois-rozet/piqa?tab=readme-ov-file#available-metrics) could be considered but I retained to use the same library (piq) to avoid any compatibility/dependency conflict.